### PR TITLE
Update README.md with `gnu-sed` installation instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Name it after the topic of the paper, with `-paper` appended to end. For example
 the RLC paper (FSE 2021) is `resource-leak-paper`. Call this new name $NAME for the rest
 of these instructions.
 2. run `sed -i "s/paper/$NAME/g" Makefile .gitignore` (on a Mac, this must be `gsed`)
-  * To install `gsed` on macOS, you can run `brew install gnu-sed` if you use
-    Homebrew.
+    * To install `gsed` on macOS, you can run `brew install gnu-sed` if you use
+      Homebrew.
 3. run `git mv paper.tex $NAME.tex`
 4. ensure that the resulting paper builds:  run `make`
 5. commit your changes and start writing!

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Name it after the topic of the paper, with `-paper` appended to end. For example
 the RLC paper (FSE 2021) is `resource-leak-paper`. Call this new name $NAME for the rest
 of these instructions.
 2. run `sed -i "s/paper/$NAME/g" Makefile .gitignore` (on a Mac, this must be `gsed`)
+  * To install `gsed` on macOS, you can run `brew install gnu-sed` if you use
+    Homebrew.
 3. run `git mv paper.tex $NAME.tex`
 4. ensure that the resulting paper builds:  run `make`
 5. commit your changes and start writing!


### PR DESCRIPTION
An internet search for installing `gsed` (i.e., the distribution of `sed` provided with GNU) yielded Homebrew as the easiest option for installation on macOS.