### PR TITLE
Remove reference to ESEC/FSE

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -33,7 +33,7 @@
 %   June 03--05, 2018, Woodstock, NY}
 % \acmPrice{15.00}
 % \acmISBN{978-1-4503-9999-9/18/06}
-\acmConference[ESEC/FSE 2021]{The 29th ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering}{23 - 27 August, 2021}{Athens, Greece}
+\acmConference[Conference \the\year]{The 1st Conference on Conferences}{1 - 4 January, \the\year}{City, Country}
 
 
 %%


### PR DESCRIPTION
This commit removes a reference to ESEC/FSE 2021, which was appearing as a header on every page.

The header now appears as

```txt
Conference 2023, 1 - 4 January, 2023, City, Country
```
where the year is automatically generated.