### PR TITLE
Add retry logic to tlmgr update command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ jobs:
         uses: actions/checkout@v3
       # As of 2023-10-21, this update is necessary to get around a bug
       # in the acmart.class in the texlive/texlive docker image.
-      - name: Update Tex Live distribution
-        run: tlmgr update --self --all
+      # retries up to 3 times in case of network failures.
+      - name: Update Tex Live distribution 
+        run: (echo "=== tlmgr update attempt 1 ===" && tlmgr update --self --all) || \
+	     (echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || \
+	     (echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
       - run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,6 @@ jobs:
       # retries up to 3 times in case of network failures.
       - name: Update Tex Live distribution 
         run: (echo "=== tlmgr update attempt 1 ===" && tlmgr update --self --all) || \
-	     (echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || \
-	     (echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
+             (echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || \
+             (echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
       - run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,5 @@ jobs:
       # in the acmart.class in the texlive/texlive docker image.
       # retries up to 3 times in case of network failures.
       - name: Update Tex Live distribution 
-        run: (echo "=== tlmgr update attempt 1 ===" && tlmgr update --self --all) || \
-             (echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || \
-             (echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
+        run: (echo "=== tlmgr update attempt 1 ===" && tlmgr update --self --all) || (echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || (echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
       - run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
           show-progress: false
       # As of 2023-10-21, this update is necessary to get around a bug
       # in the acmart.class in the texlive/texlive docker image.
-      # retries up to 3 times in case of network failures.
+      # Retry up to 3 times in case of network failures.
       - name: Update Tex Live distribution 
-        run: (echo "=== tlmgr update attempt 1 ===" && tlmgr update --self --all) || (echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || (echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
+        run: tlmgr update --self --all || (sleep 5 && echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || (sleep 15 && echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
       - run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,6 @@ jobs:
       # As of 2023-10-21, this update is necessary to get around a bug
       # in the acmart.class in the texlive/texlive docker image.
       # Retry up to 3 times in case of network failures.
-      - name: Update Tex Live distribution 
+      - name: Update Tex Live distribution
         run: tlmgr update --self --all || (sleep 5 && echo "=== tlmgr update attempt 2 ===" && tlmgr update --self --all) || (sleep 15 && echo "=== tlmgr update attempt 3 ===" && tlmgr update --self --all)
       - run: make


### PR DESCRIPTION
I've encountered some CI flakiness from this update command recently that's been resolvable by re-running the failed workflow manually; hopefully this will make that automatic.