### PR TITLE
Update GitHub actions version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       image: texlive/texlive
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           show-progress: false


### PR DESCRIPTION
Installing Renovate (browse to https://github.com/apps/renovate, click "Install", choose GitHub org, select specific repositories) would prevent the need for pull requests like this.