### PR TITLE
Adding `paper-ieee.pdf` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ onefile.tex
 paper.pdf
 paper-notodos.pdf
 paper-long.pdf
+paper-ieee.pdf
 misspelled-words.txt
 
 ## emacs temp files


### PR DESCRIPTION
It would be shorter to add `paper-*.pdf` to the `.gitignore`, but that might not be desirable.